### PR TITLE
fix(line-counter): detect compression extension case-insensitively

### DIFF
--- a/.changeset/case-insensitive-compression.md
+++ b/.changeset/case-insensitive-compression.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.software-small-binaries.line-counter": patch
+---
+
+Detect the compression extension case-insensitively. A file with an uppercase or
+mixed-case suffix (`.GZ`, `.Zst`, …) is now decompressed before counting instead
+of being read raw and miscounted.

--- a/line-counter/README.md
+++ b/line-counter/README.md
@@ -12,6 +12,6 @@ Usage:
 
 Counts the number of lines (`'\n'` bytes) in `--input` and writes the exact
 count as a base-10 integer (no trailing newline) into `--output`. Compression
-is inferred from the input file extension: `.gz`, `.bz2`, `.zst`, otherwise the
-file is read as-is. The file is streamed, so memory usage is O(1) regardless of
-file size.
+is inferred (case-insensitively) from the input file extension: `.gz`, `.bz2`,
+`.zst`, otherwise the file is read as-is. The file is streamed, so memory usage
+is O(1) regardless of file size.

--- a/line-counter/internal/count.go
+++ b/line-counter/internal/count.go
@@ -12,7 +12,8 @@ import (
 )
 
 // CountLines returns the number of '\n' bytes in the (optionally compressed) file.
-// Compression is inferred from the file extension: .gz, .bz2, .zst, else raw.
+// Compression is inferred from the file extension (case-insensitively): .gz,
+// .bz2, .zst, else raw.
 func CountLines(path string) (int64, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -20,18 +21,21 @@ func CountLines(path string) (int64, error) {
 	}
 	defer f.Close()
 
+	// Match the suffix case-insensitively (real-world inputs use .GZ, .Zst, …);
+	// open() above still uses the original path.
+	ext := strings.ToLower(path)
 	var r io.Reader = f
 	switch {
-	case strings.HasSuffix(path, ".gz"):
+	case strings.HasSuffix(ext, ".gz"):
 		gz, err := gzip.NewReader(f)
 		if err != nil {
 			return 0, err
 		}
 		defer gz.Close()
 		r = gz
-	case strings.HasSuffix(path, ".bz2"):
+	case strings.HasSuffix(ext, ".bz2"):
 		r = bzip2.NewReader(f)
-	case strings.HasSuffix(path, ".zst"):
+	case strings.HasSuffix(ext, ".zst"):
 		zr, err := zstd.NewReader(f)
 		if err != nil {
 			return 0, err

--- a/line-counter/internal/count_test.go
+++ b/line-counter/internal/count_test.go
@@ -75,6 +75,11 @@ func TestCountLines(t *testing.T) {
 		{"zstd", func(t *testing.T) string { return writeZstd(t, "a.txt.zst", []byte("1\n2\n3\n4\n")) }, 4},
 		// stdlib has no bzip2 writer, so read a committed fixture (3 lines).
 		{"bzip2_fixture", func(t *testing.T) string { return "testdata/sample.txt.bz2" }, 3},
+		// case-insensitive suffix detection: a compression extension in upper or
+		// mixed case must still trigger decompression (real-world inputs vary in
+		// casing). Without it the compressed bytes are read raw and miscounted.
+		{"gzip_uppercase_ext", func(t *testing.T) string { return writeGzip(t, "a.txt.GZ", []byte("x\ny\n")) }, 2},
+		{"zstd_mixedcase_ext", func(t *testing.T) string { return writeZstd(t, "a.txt.Zst", []byte("1\n2\n3\n4\n")) }, 4},
 		// boundary: an empty file has zero newlines.
 		{"empty", func(t *testing.T) string { return writeFile(t, "empty.txt", []byte("")) }, 0},
 		// CONTRACT: count is the number of '\n', so a final line with no


### PR DESCRIPTION
## Problem

`line-counter` infers compression from the input file extension, but the switch used a **case-sensitive** suffix check:

```go
case strings.HasSuffix(path, ".gz"):  // also .bz2, .zst
```

So a file with an uppercase or mixed-case suffix (`reads.fastq.GZ`, `data.Zst`) was **not** decompressed — it was read raw and the line count was the number of `'\n'` bytes in the *compressed* stream. Silent garbage, no error. Verified on the built binary: an uppercase `.GZ` of a 3-line file returns `1` instead of `3`.

## Fix

Lowercase the path for the suffix comparison only; `os.Open` still uses the original path. Covers `.GZ`, `.BZ2`, `.ZST`, and mixed case like `.Zst`. The counting loop and the no-trailing-newline semantics are untouched.

## Tests

Added two cases to the `TestCountLines` table — uppercase `.GZ` and mixed-case `.Zst` — both asserting the decompressed count. They fail on the old code (`0`/raw count) and pass with the fix. `./test.sh` (Go unit + bash integration) is green.

## Context

This unblocks the platforma resource-formula `f.lineCount()` feature: the SDK currently rejects uppercase-compressed inputs to mirror this binary's old behavior. Once this is released, the SDK side will be relaxed to accept them (case-insensitive compression detection there too).